### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Step 3 :
 
 ---------------------------------------------------------------------------------
 
+---------------------------------------------------------------------------------
+Minor Fix 1 : Fixed Permissions for managing cogs
+
+Now the load, unload and reload commands require administrator permissions for a user in order to use them, and flashes error message if they don't have necessary permissions.
+This is implemented by using checks and handling errors.
+
+---------------------------------------------------------------------------------
+
 So, following the above steps one can easily deploy the bot on a local machine.
 
 Documentation for advanced and specific functions will be updated shortly.

--- a/src/cogs/basic.py
+++ b/src/cogs/basic.py
@@ -37,7 +37,7 @@ class basic(commands.Cog):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.send('Please specify an amount of messages to be deleted!')
         elif isinstance(error, commands.MissingPermissions):
-            await ctx.send('Missing ```Manage Messages``` Permissions!')
+            await ctx.send('Missing `Manage Messages` Permissions!')
 
 
 def setup(client):

--- a/src/main.py
+++ b/src/main.py
@@ -7,30 +7,42 @@ intents.members=True
 
 client=commands.Bot(command_prefix='-',intents=intents)
 
-missing_perms = ['administrator']
 
 @client.event
 async def on_command_error(ctx, error):
     if isinstance(error, commands.CommandNotFound):
         await ctx.send("Invalid Command!")
-    elif isinstance(error, commands.MissingPermissions(missing_perms)):
-        await ctx.send("Must have `administrator` permissions to use this command!")
 
 @client.command()
 @commands.has_permissions(administrator=True)
 async def load(ctx, extension):
     client.load_extension(f'cogs.{extension}')
 
+@load.error
+async def on_load_error(ctx, error):
+    if isinstance(error, commands.MissingPermissions):
+        await ctx.send("Must have `administrator` permissions to use this command!")
+
 @client.command()
 @commands.has_permissions(administrator=True)
 async def unload(ctx, extension):
     client.unload_extension(f'cogs.{extension}')
+
+@unload.error
+async def on_unload_error(ctx, error):
+    if isinstance(error, commands.MissingPermissions):
+        await ctx.send("Must have `administrator` permissions to use this command!")
 
 @client.command()
 @commands.has_permissions(administrator=True)
 async def reload(ctx, extension):
     client.unload_extension(f'cogs.{extension}')
     client.load_extension(f'cogs.{extension}')
+
+@reload.error
+async def on_reload_error(ctx, error):
+    if isinstance(error, commands.MissingPermissions):
+        await ctx.send("Must have `administrator` permissions to use this command!")
 
 for filename in os.listdir('./cogs'):
     if filename.endswith('.py'):

--- a/src/main.py
+++ b/src/main.py
@@ -7,15 +7,25 @@ intents.members=True
 
 client=commands.Bot(command_prefix='-',intents=intents)
 
+@client.event
+async def on_command_error(ctx, error):
+    if isinstance(error, commands.CommandNotFound):
+        await ctx.send("Invalid Command!")
+    elif isinstance(error, commands.MissingPermissions):
+        await ctx.send("Must have ```administrator``` permissions to use this command!")
+
 @client.command()
+@commands.has_permissions(administrator=True)
 async def load(ctx, extension):
     client.load_extension(f'cogs.{extension}')
 
 @client.command()
+@commands.has_permissions(administrator=True)
 async def unload(ctx, extension):
     client.unload_extension(f'cogs.{extension}')
 
 @client.command()
+@commands.has_permissions(administrator=True)
 async def reload(ctx, extension):
     client.unload_extension(f'cogs.{extension}')
     client.load_extension(f'cogs.{extension}')

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,7 @@ client=commands.Bot(command_prefix='-',intents=intents)
 async def on_command_error(ctx, error):
     if isinstance(error, commands.CommandNotFound):
         await ctx.send("Invalid Command!")
-    elif isinstance(error, commands.MissingPermissions):
+    elif isinstance(error, commands.MissingPermissions(administrator=True)):
         await ctx.send("Must have ```administrator``` permissions to use this command!")
 
 @client.command()

--- a/src/main.py
+++ b/src/main.py
@@ -7,11 +7,13 @@ intents.members=True
 
 client=commands.Bot(command_prefix='-',intents=intents)
 
+missing_perms = ['administrator']
+
 @client.event
 async def on_command_error(ctx, error):
     if isinstance(error, commands.CommandNotFound):
         await ctx.send("Invalid Command!")
-    elif isinstance(error, commands.MissingPermissions(administrator=True)):
+    elif isinstance(error, commands.MissingPermissions(missing_perms)):
         await ctx.send("Must have `administrator` permissions to use this command!")
 
 @client.command()

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ async def on_command_error(ctx, error):
     if isinstance(error, commands.CommandNotFound):
         await ctx.send("Invalid Command!")
     elif isinstance(error, commands.MissingPermissions(administrator=True)):
-        await ctx.send("Must have ```administrator``` permissions to use this command!")
+        await ctx.send("Must have `administrator` permissions to use this command!")
 
 @client.command()
 @commands.has_permissions(administrator=True)


### PR DESCRIPTION
@Dsantra92 
Fixed permissions for managing cogs.
Updated Readme.
Changes : Now, only users with 'administrator' permissions can load, unload or reload cogs.
Error message is displayed in the channel if they are missing necessary permissions.