### PR TITLE
Added embeds for all basic bot commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,3 @@ dmypy.json
 .pyre/
 .DS_Store
 token.txt
-s4dsbot

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 .pyre/
 .DS_Store
 token.txt
+s4dsbot

--- a/src/cogs/basic.py
+++ b/src/cogs/basic.py
@@ -3,7 +3,7 @@ from discord.enums import Status
 from discord.ext import commands, tasks
 from itertools import cycle
 
-status = cycle(['arXiv','Kaggle'])
+status = cycle(['arXiv','Kaggle','redditAPI'])
 
 class basic(commands.Cog):
     def __init__(self, client):
@@ -25,7 +25,11 @@ class basic(commands.Cog):
 
     @commands.command()
     async def ping(self, ctx):
-        await ctx.send(f'Pong! In {round(self.client.latency*1000)} ms.')
+        embed=discord.Embed(title="Ping",
+        description=f'Pong! In {round(self.client.latency*1000)} ms.',
+        color=discord.Color.dark_gold())
+        embed.set_footer(text=f'Information requested by : {ctx.author.id}')
+        await ctx.send(embed)
 
     @commands.command()
     @commands.has_permissions(manage_messages=True)

--- a/src/cogs/basic.py
+++ b/src/cogs/basic.py
@@ -1,60 +1,74 @@
+#Imports
 import discord
 from discord.enums import Status 
 from discord.ext import commands, tasks
 from itertools import cycle
 import asyncio
 
-status = cycle(['arXiv','Kaggle','redditAPI'])
+#Cycle which consists of the bot statuses to be cycled through at regular intervals
+status = cycle(['arXiv', 'Kaggle', 'redditAPI'])
 
+#Create a class `basic` which inherits from the `commands.Cog` class
 class basic(commands.Cog):
     def __init__(self, client):
-        self.client=client
+        self.client = client
 
+    #Event (Cog.listener()) event which prints online status of bot on console 
+    # and triggers status/activity cycle of bot
     @commands.Cog.listener()
     async def on_ready(self):
         self.change_status.start()
         print("Bot is ready")
 
-    @tasks.loop(seconds=15)
+    #Loop that cycles bot status at every 15 seconds
+    @tasks.loop(seconds = 15)
     async def change_status(self):
-        await self.client.change_presence(activity=discord.Game(next(status)))
+        await self.client.change_presence(activity = discord.Game(next(status)))
 
+    #Command that returns latency of the client in channel where it is triggered
     @commands.command()
     async def ping(self, ctx):
-        embed=discord.Embed(title="Ping",
-        description=f'Pong! In {round(self.client.latency*1000)} ms.',
-        color=discord.Color.green())
-        embed.set_footer(text=f'Information requested by : {ctx.author.display_name}')
-        await ctx.send(embed=embed)
+        embed = discord.Embed(title = "Ping",
+        description = f'Pong! In {round(self.client.latency*1000)} ms.',
+        color = discord.Color.green())
+        embed.set_footer(text = f'Information requested by : {ctx.author.display_name}')
+        await ctx.send(embed = embed)
 
+    #Command that deletes a specified number of messages from the channel 
+    # where it is triggered
     @commands.command()
-    @commands.has_permissions(manage_messages=True)
+    @commands.has_permissions(manage_messages = True)
     async def clear(self, ctx, amount : int):
-        await ctx.channel.purge(limit=amount)
-        embed=discord.Embed(title="Purged Messages!",description=f'{amount} messages have been cleared.',
-        color=discord.Color.teal())
-        await ctx.send(embed=embed)
+        await ctx.channel.purge(limit = amount)
+        embed = discord.Embed(title = "Purged Messages!", description = f'{amount} messages have been cleared.',
+        color = discord.Color.teal())
+        await ctx.send(embed = embed)
         await asyncio.sleep(2)
-        await ctx.channel.purge(limit=1)
+        await ctx.channel.purge(limit = 1)
 
+    #Error handler for `clear` command
     @clear.error
     async def on_command_err(self, ctx, error):
+        #Error displayed in text channel when required argument is not provided
         if isinstance(error, commands.MissingRequiredArgument):
-            embed_title="Missing Required Argument!"
-            embed_desc="Please specify an amount of messages to be deleted!"
-            embed_color=discord.Color.orange()
-            #await ctx.send('Please specify an amount of messages to be deleted!')
+            embed_title = "Missing Required Argument!"
+            embed_desc = "Please specify an amount of messages to be deleted!"
+            embed_color = discord.Color.orange()
+        
+        #Error displayed in text channel when user does not have permissions required
+        #  to trigger the command
         elif isinstance(error, commands.MissingPermissions):
-            embed_title="Missing Permissions!"
-            embed_desc="Missing `Manage Messages` Permissions!"
-            embed_color=discord.Color.red()
-            #await ctx.send('Missing `Manage Messages` Permissions!')
+            embed_title = "Missing Permissions!"
+            embed_desc = "Missing `Manage Messages` Permissions!"
+            embed_color = discord.Color.red()
         else:
             return
-        embed=discord.Embed(title=embed_title,description=embed_desc,color=embed_color)
-        embed.set_footer(text=f'Command error encountered by : {ctx.author.display_name}')
-        await ctx.send(embed=embed)
+        embed = discord.Embed(title = embed_title, description = embed_desc, 
+        color = embed_color)
+        embed.set_footer(text = f'Command error encountered by : {ctx.author.display_name}')
+        await ctx.send(embed = embed)
 
+#Setup cogs `basic`
 def setup(client):
     client.add_cog(basic(client))
 

--- a/src/cogs/basic.py
+++ b/src/cogs/basic.py
@@ -1,31 +1,31 @@
-#Imports
+# Imports
 import discord
 from discord.enums import Status 
 from discord.ext import commands, tasks
 from itertools import cycle
 import asyncio
 
-#Cycle which consists of the bot statuses to be cycled through at regular intervals
+# Cycle which consists of the bot statuses to be cycled through at regular intervals
 status = cycle(['arXiv', 'Kaggle', 'redditAPI'])
 
-#Create a class `basic` which inherits from the `commands.Cog` class
+# Create a class `basic` which inherits from the `commands.Cog` class
 class basic(commands.Cog):
     def __init__(self, client):
         self.client = client
 
-    #Event (Cog.listener()) event which prints online status of bot on console 
+    # Event (Cog.listener()) event which prints online status of bot on console 
     # and triggers status/activity cycle of bot
     @commands.Cog.listener()
     async def on_ready(self):
         self.change_status.start()
         print("Bot is ready")
 
-    #Loop that cycles bot status at every 15 seconds
+    # Loop that cycles bot status at every 15 seconds
     @tasks.loop(seconds = 15)
     async def change_status(self):
         await self.client.change_presence(activity = discord.Game(next(status)))
 
-    #Command that returns latency of the client in channel where it is triggered
+    # Command that returns latency of the client in channel where it is triggered
     @commands.command()
     async def ping(self, ctx):
         embed = discord.Embed(title = "Ping",
@@ -34,7 +34,7 @@ class basic(commands.Cog):
         embed.set_footer(text = f'Information requested by : {ctx.author.display_name}')
         await ctx.send(embed = embed)
 
-    #Command that deletes a specified number of messages from the channel 
+    # Command that deletes a specified number of messages from the channel 
     # where it is triggered
     @commands.command()
     @commands.has_permissions(manage_messages = True)
@@ -46,17 +46,17 @@ class basic(commands.Cog):
         await asyncio.sleep(2)
         await ctx.channel.purge(limit = 1)
 
-    #Error handler for `clear` command
+    # Error handler for `clear` command
     @clear.error
     async def on_command_err(self, ctx, error):
-        #Error displayed in text channel when required argument is not provided
+        # Error displayed in text channel when required argument is not provided
         if isinstance(error, commands.MissingRequiredArgument):
             embed_title = "Missing Required Argument!"
             embed_desc = "Please specify an amount of messages to be deleted!"
             embed_color = discord.Color.orange()
         
-        #Error displayed in text channel when user does not have permissions required
-        #  to trigger the command
+        # Error displayed in text channel when user does not have permissions required
+        # to trigger the command
         elif isinstance(error, commands.MissingPermissions):
             embed_title = "Missing Permissions!"
             embed_desc = "Missing `Manage Messages` Permissions!"
@@ -68,7 +68,7 @@ class basic(commands.Cog):
         embed.set_footer(text = f'Command error encountered by : {ctx.author.display_name}')
         await ctx.send(embed = embed)
 
-#Setup cogs `basic`
+# Setup cogs `basic`
 def setup(client):
     client.add_cog(basic(client))
 

--- a/src/cogs/games.py
+++ b/src/cogs/games.py
@@ -5,20 +5,21 @@ from discord.ext import commands
 class games(commands.Cog):
     def __init__(self, client):
         self.client=client
-
-    '''@commands.Cog.listener()
-    async def on_ready(self):
-        print("Bot is onlyn")'''
     
     @commands.command(aliases = ['cf','tosscoin','tc'])
     async def coinflip(self, ctx):
         cf_res = ['Heads','Tails']
-        await ctx.send(f'{random.choice(cf_res)}')
+        res = random.choice(cf_res)
+        embed = discord.Embed(title="Coinflip",description=f'Result = {res}!',color=discord.Color.gold())
+        await ctx.send(embed=embed)
 
     @commands.command(aliases = ['die','6face'])
     async def tossdie(self, ctx):
         td_res = [int(i) for i in range(1,7)]
-        await ctx.send(f'{random.choice(td_res)}')
+        res = random.choice(td_res)
+        embed = discord.Embed(title="Toss A Die",description=f'Result = {res}!',
+        color=discord.Color.magenta())
+        await ctx.send(embed=embed)
 
 def setup(client):
     client.add_cog(games(client))

--- a/src/cogs/games.py
+++ b/src/cogs/games.py
@@ -1,25 +1,31 @@
+#Imports
 import discord
 import random
 from discord.ext import commands
 
+#Create a class `games` which inherits from the `commands.Cog` class
 class games(commands.Cog):
     def __init__(self, client):
-        self.client=client
+        self.client = client
     
-    @commands.command(aliases = ['cf','tosscoin','tc'])
+    #Command for `coinflip` 
+    @commands.command(aliases = ['cf', 'tosscoin', 'tc'])
     async def coinflip(self, ctx):
-        cf_res = ['Heads','Tails']
+        cf_res = ['Heads', 'Tails']
         res = random.choice(cf_res)
-        embed = discord.Embed(title="Coinflip",description=f'Result = {res}!',color=discord.Color.gold())
-        await ctx.send(embed=embed)
+        embed = discord.Embed(title = "Coinflip", description = f'Result = {res}!', 
+        color = discord.Color.gold())
+        await ctx.send(embed = embed)
 
-    @commands.command(aliases = ['die','6face'])
+    #Command for `die toss`
+    @commands.command(aliases = ['die', '6face'])
     async def tossdie(self, ctx):
         td_res = [int(i) for i in range(1,7)]
         res = random.choice(td_res)
-        embed = discord.Embed(title="Toss A Die",description=f'Result = {res}!',
-        color=discord.Color.magenta())
-        await ctx.send(embed=embed)
+        embed = discord.Embed(title = "Toss A Die", description = f'Result = {res}!',
+        color = discord.Color.magenta())
+        await ctx.send(embed = embed)
 
+#Setup cogs `games`
 def setup(client):
     client.add_cog(games(client))

--- a/src/cogs/games.py
+++ b/src/cogs/games.py
@@ -1,14 +1,14 @@
-#Imports
+# Imports
 import discord
 import random
 from discord.ext import commands
 
-#Create a class `games` which inherits from the `commands.Cog` class
+# Create a class `games` which inherits from the `commands.Cog` class
 class games(commands.Cog):
     def __init__(self, client):
         self.client = client
     
-    #Command for `coinflip` 
+    # Command for `coinflip` 
     @commands.command(aliases = ['cf', 'tosscoin', 'tc'])
     async def coinflip(self, ctx):
         cf_res = ['Heads', 'Tails']
@@ -17,7 +17,7 @@ class games(commands.Cog):
         color = discord.Color.gold())
         await ctx.send(embed = embed)
 
-    #Command for `die toss`
+    # Command for `die toss`
     @commands.command(aliases = ['die', '6face'])
     async def tossdie(self, ctx):
         td_res = [int(i) for i in range(1,7)]
@@ -26,6 +26,6 @@ class games(commands.Cog):
         color = discord.Color.magenta())
         await ctx.send(embed = embed)
 
-#Setup cogs `games`
+# Setup cogs `games`
 def setup(client):
     client.add_cog(games(client))

--- a/src/main.py
+++ b/src/main.py
@@ -11,7 +11,9 @@ client=commands.Bot(command_prefix='-',intents=intents)
 @client.event
 async def on_command_error(ctx, error):
     if isinstance(error, commands.CommandNotFound):
-        await ctx.send("Invalid Command!")
+        embed=discord.Embed(title="Invalid Command!",description="Command Not Found!",
+        color=discord.Color.dark_red())
+        await ctx.send(embed=embed)
 
 @client.command()
 @commands.has_permissions(administrator=True)
@@ -21,7 +23,10 @@ async def load(ctx, extension):
 @load.error
 async def on_load_error(ctx, error):
     if isinstance(error, commands.MissingPermissions):
-        await ctx.send("Must have `administrator` permissions to use this command!")
+        embed=discord.Embed(title="Missing Permissions!",
+        description="Must have `administrator` permissions to use this command!",
+        color=discord.Color.greyple())
+        await ctx.send(embed=embed)
 
 @client.command()
 @commands.has_permissions(administrator=True)
@@ -30,8 +35,10 @@ async def unload(ctx, extension):
 
 @unload.error
 async def on_unload_error(ctx, error):
-    if isinstance(error, commands.MissingPermissions):
-        await ctx.send("Must have `administrator` permissions to use this command!")
+    embed=discord.Embed(title="Missing Permissions!",
+    description="Must have `administrator` permissions to use this command!",
+    color=discord.Color.greyple())
+    await ctx.send(embed=embed)
 
 @client.command()
 @commands.has_permissions(administrator=True)
@@ -41,8 +48,10 @@ async def reload(ctx, extension):
 
 @reload.error
 async def on_reload_error(ctx, error):
-    if isinstance(error, commands.MissingPermissions):
-        await ctx.send("Must have `administrator` permissions to use this command!")
+    embed=discord.Embed(title="Missing Permissions!",
+    description="Must have `administrator` permissions to use this command!",
+    color=discord.Color.greyple())
+    await ctx.send(embed=embed)
 
 for filename in os.listdir('./cogs'):
     if filename.endswith('.py'):

--- a/src/main.py
+++ b/src/main.py
@@ -1,16 +1,16 @@
-#Imports
+# Imports
 import discord
 import os
 from discord.ext import commands
 
-#Managing default and priviledged gateway intents
+# Managing default and priviledged gateway intents
 intents = discord.Intents.default()
 intents.members = True
 
-#Create instance of a bot object
+# Create instance of a bot object
 client = commands.Bot(command_prefix = '-', intents = intents)
 
-#Error message displayed in discord channel in case invalid command is entered
+# Error message displayed in discord channel in case invalid command is entered
 @client.event
 async def on_command_error(ctx, error):
     if isinstance(error, commands.CommandNotFound):
@@ -18,13 +18,13 @@ async def on_command_error(ctx, error):
         color = discord.Color.dark_red())
         await ctx.send(embed = embed)
 
-#Command to load cogs while bot is online
+# Command to load cogs while bot is online
 @client.command()
 @commands.has_permissions(administrator = True)
 async def load(ctx, extension):
     client.load_extension(f'cogs.{extension}')
 
-#Error message displayed when user triggers `load` command without 
+# Error message displayed when user triggers `load` command without 
 # being granted required permissions
 @load.error
 async def on_load_error(ctx, error):
@@ -34,13 +34,13 @@ async def on_load_error(ctx, error):
         color = discord.Color.greyple())
         await ctx.send(embed = embed)
 
-#Command to unload cogs when bot is online
+# Command to unload cogs when bot is online
 @client.command()
 @commands.has_permissions(administrator = True)
 async def unload(ctx, extension):
     client.unload_extension(f'cogs.{extension}')
 
-#Error message displayed when user triggers `unload` command without 
+# Error message displayed when user triggers `unload` command without 
 # being granted required permissions
 @unload.error
 async def on_unload_error(ctx, error):
@@ -49,7 +49,7 @@ async def on_unload_error(ctx, error):
     color = discord.Color.greyple())
     await ctx.send(embed = embed)
 
-#Command to reload (unload then load) cogs when bot is online. It serves as 
+# Command to reload (unload then load) cogs when bot is online. It serves as 
 # an efficient way to add/remove/update/fix cogs while bot is actively serving
 # its purpose.
 @client.command()
@@ -58,7 +58,7 @@ async def reload(ctx, extension):
     client.unload_extension(f'cogs.{extension}')
     client.load_extension(f'cogs.{extension}')
 
-#Error message displayed when user triggers `reload` command without 
+# Error message displayed when user triggers `reload` command without 
 # being granted required permissions
 @reload.error
 async def on_reload_error(ctx, error):
@@ -67,15 +67,15 @@ async def on_reload_error(ctx, error):
     color = discord.Color.greyple())
     await ctx.send(embed = embed)
 
-#Loop that loads cogs when bot is online
+# Loop that loads cogs when bot is online
 for filename in os.listdir('./cogs'):
     if filename.endswith('.py'):
         client.load_extension(f'cogs.{filename[:-3]}')
 
-#Read token from file (local machine) or environment (deployment)
+# Read token from file (local machine) or environment (deployment)
 f = open("token.txt", "r")
 token = f.read()
 f.close()
 
-#Code to run the bot
+# Code to run the bot
 client.run(token)

--- a/src/main.py
+++ b/src/main.py
@@ -1,64 +1,81 @@
+#Imports
 import discord
 import os
 from discord.ext import commands
 
-intents=discord.Intents.default()
-intents.members=True
+#Managing default and priviledged gateway intents
+intents = discord.Intents.default()
+intents.members = True
 
-client=commands.Bot(command_prefix='-',intents=intents)
+#Create instance of a bot object
+client = commands.Bot(command_prefix = '-', intents = intents)
 
-
+#Error message displayed in discord channel in case invalid command is entered
 @client.event
 async def on_command_error(ctx, error):
     if isinstance(error, commands.CommandNotFound):
-        embed=discord.Embed(title="Invalid Command!",description="Command Not Found!",
-        color=discord.Color.dark_red())
-        await ctx.send(embed=embed)
+        embed = discord.Embed(title = "Invalid Command!", description = "Command Not Found!",
+        color = discord.Color.dark_red())
+        await ctx.send(embed = embed)
 
+#Command to load cogs while bot is online
 @client.command()
-@commands.has_permissions(administrator=True)
+@commands.has_permissions(administrator = True)
 async def load(ctx, extension):
     client.load_extension(f'cogs.{extension}')
 
+#Error message displayed when user triggers `load` command without 
+# being granted required permissions
 @load.error
 async def on_load_error(ctx, error):
     if isinstance(error, commands.MissingPermissions):
-        embed=discord.Embed(title="Missing Permissions!",
-        description="Must have `administrator` permissions to use this command!",
-        color=discord.Color.greyple())
-        await ctx.send(embed=embed)
+        embed = discord.Embed(title = "Missing Permissions!",
+        description = "Must have `administrator` permissions to use this command!",
+        color = discord.Color.greyple())
+        await ctx.send(embed = embed)
 
+#Command to unload cogs when bot is online
 @client.command()
-@commands.has_permissions(administrator=True)
+@commands.has_permissions(administrator = True)
 async def unload(ctx, extension):
     client.unload_extension(f'cogs.{extension}')
 
+#Error message displayed when user triggers `unload` command without 
+# being granted required permissions
 @unload.error
 async def on_unload_error(ctx, error):
-    embed=discord.Embed(title="Missing Permissions!",
-    description="Must have `administrator` permissions to use this command!",
-    color=discord.Color.greyple())
-    await ctx.send(embed=embed)
+    embed = discord.Embed(title = "Missing Permissions!",
+    description = "Must have `administrator` permissions to use this command!",
+    color = discord.Color.greyple())
+    await ctx.send(embed = embed)
 
+#Command to reload (unload then load) cogs when bot is online. It serves as 
+# an efficient way to add/remove/update/fix cogs while bot is actively serving
+# its purpose.
 @client.command()
-@commands.has_permissions(administrator=True)
+@commands.has_permissions(administrator = True)
 async def reload(ctx, extension):
     client.unload_extension(f'cogs.{extension}')
     client.load_extension(f'cogs.{extension}')
 
+#Error message displayed when user triggers `reload` command without 
+# being granted required permissions
 @reload.error
 async def on_reload_error(ctx, error):
-    embed=discord.Embed(title="Missing Permissions!",
-    description="Must have `administrator` permissions to use this command!",
-    color=discord.Color.greyple())
-    await ctx.send(embed=embed)
+    embed = discord.Embed(title = "Missing Permissions!",
+    description = "Must have `administrator` permissions to use this command!",
+    color = discord.Color.greyple())
+    await ctx.send(embed = embed)
 
+#Loop that loads cogs when bot is online
 for filename in os.listdir('./cogs'):
     if filename.endswith('.py'):
         client.load_extension(f'cogs.{filename[:-3]}')
 
-f=open("token.txt","r")
+#Read token from file (local machine) or environment (deployment)
+f = open("token.txt", "r")
 token = f.read()
 f.close()
 
+#Code to run the bot
 client.run(token)


### PR DESCRIPTION
@Dsantra92 
all basic bot commands and error messages give errors in vibrant embeds.

<details>
<summary>Image showing new vibrant embeds for bot command outputs and error messages.</summary>
<img width="564" alt="Screenshot 2021-08-14 at 11 04 30 PM" src="https://user-images.githubusercontent.com/77383234/129455633-6748f22e-4059-4a11-8180-030181e9c9b4.png">
</details>